### PR TITLE
patch 0.7.7 with sha3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ thiserror = "1.0"
 k256 = { version = "0.13", default-features = false }
 keccak-asm = { version = "0.1.0", default-features = false }
 tiny-keccak = "2.0"
+sha3 = "0.10.8"
 
 # misc
 allocative = { version = "0.3.2", default-features = false }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -28,6 +28,7 @@ itoa.workspace = true
 ruint.workspace = true
 tiny-keccak = { workspace = true, features = ["keccak"] }
 keccak-asm = { workspace = true, optional = true }
+sha3.workspace = true
 
 # macros
 derive_more.workspace = true

--- a/crates/primitives/src/utils/mod.rs
+++ b/crates/primitives/src/utils/mod.rs
@@ -180,7 +180,7 @@ pub fn keccak256<T: AsRef<[u8]>>(bytes: T) -> B256 {
                 // SAFETY: Never reads from `output`.
                 unsafe { hasher.finalize_into_raw(output.as_mut_ptr().cast()) };
             } else {
-                let mut hasher = sha3::Sha3_256::new();
+                let mut hasher = sha3::Keccak256::new();
                 hasher.update(bytes);
                 // SAFETY: Never reads from `output`.
                 unsafe {
@@ -209,7 +209,7 @@ pub struct Keccak256 {
     #[cfg(feature = "tiny-keccak")]
     hasher: tiny_keccak::Keccak,
     #[cfg(not(any(feature = "asm-keccak", feature = "tiny-keccak")))]
-    hasher: sha3::Sha3_256,
+    hasher: sha3::Keccak256,
 }
 
 impl Default for Keccak256 {
@@ -236,7 +236,7 @@ impl Keccak256 {
             } else if #[cfg(feature = "tiny-keccak")] {
                 let hasher = tiny_keccak::Keccak::v256();
             } else {
-                let hasher = sha3::Sha3_256::new();
+                let hasher = sha3::Keccak256::new();
             }
         }
         Self { hasher }

--- a/crates/primitives/src/utils/mod.rs
+++ b/crates/primitives/src/utils/mod.rs
@@ -276,7 +276,7 @@ impl Keccak256 {
             if #[cfg(all(feature = "asm-keccak", not(miri)))] {
                 self.hasher.finalize_into(output.into());
             } else if #[cfg(feature = "tiny-keccak")] {
-                self.hasher.finalize(output.into());
+                self.hasher.finalize(output);
             } else {
                 self.hasher.finalize_into(output.into());
             }

--- a/crates/primitives/src/utils/mod.rs
+++ b/crates/primitives/src/utils/mod.rs
@@ -4,6 +4,7 @@ use crate::B256;
 use alloc::{boxed::Box, collections::TryReserveError, vec::Vec};
 use cfg_if::cfg_if;
 use core::{fmt, mem::MaybeUninit};
+use sha3::Digest;
 
 mod units;
 pub use units::{

--- a/crates/primitives/src/utils/mod.rs
+++ b/crates/primitives/src/utils/mod.rs
@@ -276,7 +276,7 @@ impl Keccak256 {
             if #[cfg(all(feature = "asm-keccak", not(miri)))] {
                 self.hasher.finalize_into(output.into());
             } else if #[cfg(feature = "tiny-keccak")] {
-                self.hasher.finalize_into(output.into());
+                self.hasher.finalize(output.into());
             } else {
                 self.hasher.finalize_into(output.into());
             }

--- a/crates/sol-macro-expander/Cargo.toml
+++ b/crates/sol-macro-expander/Cargo.toml
@@ -33,6 +33,7 @@ hex.workspace = true
 indexmap = "2"
 proc-macro-error.workspace = true
 tiny-keccak = { workspace = true, features = ["keccak"] }
+sha3.workspace = true
 
 # json
 alloy-json-abi = { workspace = true, optional = true }

--- a/crates/sol-macro-expander/src/utils.rs
+++ b/crates/sol-macro-expander/src/utils.rs
@@ -1,17 +1,16 @@
 use ast::Spanned;
 use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
-use tiny_keccak::{Hasher, Keccak};
+use sha3::Digest;
 
 /// Simple interface to the [`keccak256`] hash function.
 ///
 /// [`keccak256`]: https://en.wikipedia.org/wiki/SHA-3
 pub(crate) fn keccak256<T: AsRef<[u8]>>(bytes: T) -> [u8; 32] {
-    let mut output = [0u8; 32];
-    let mut hasher = Keccak::v256();
+    let mut hasher = sha3::Sha3_256::new();
     hasher.update(bytes.as_ref());
-    hasher.finalize(&mut output);
-    output
+    let hash = hasher.finalize();
+    hash.to_vec().try_into().unwrap()
 }
 
 pub(crate) fn selector<T: AsRef<[u8]>>(bytes: T) -> ExprArray<u8> {

--- a/crates/sol-macro-expander/src/utils.rs
+++ b/crates/sol-macro-expander/src/utils.rs
@@ -7,7 +7,7 @@ use sha3::Digest;
 ///
 /// [`keccak256`]: https://en.wikipedia.org/wiki/SHA-3
 pub(crate) fn keccak256<T: AsRef<[u8]>>(bytes: T) -> [u8; 32] {
-    let mut hasher = sha3::Sha3_256::new();
+    let mut hasher = sha3::Keccak256::new();
     hasher.update(bytes.as_ref());
     let hash = hasher.finalize();
     hash.to_vec().try_into().unwrap()


### PR DESCRIPTION
Modify the default behavior of `alloy-primitives` to use `sha3`

`sha3` is 95% of `tiny-keccak` time on CPU and is `50%` of `tiny-keccak` time in SP1.